### PR TITLE
Makes sure that one .tsv finishing files are used when merging 

### DIFF
--- a/sh/ensembl/mergePropertiesIntoMatrix.pl
+++ b/sh/ensembl/mergePropertiesIntoMatrix.pl
@@ -94,7 +94,7 @@ if ($help) { usage($commandLine); die; }
 
 #List files in the $indir directory which are like: $species.$bioentity.*.tsv
 opendir (DIR, $indir);
-my @A_fileList = grep { (/$species\.$bioentity\..+?\.t/)} readdir(DIR);
+my @A_fileList = grep { (/$species\.$bioentity\..+?\.tsv$/)} readdir(DIR);
 closedir DIR ;
 
 #Die if no file returned


### PR DESCRIPTION
Currently the biomart/scala code can generate among its results `*.tsv.failed` files, which are usually empty:

```
cd $ATLAS_PROD/bioentity_properties/archive/wbps_14
ls -l | grep .failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 21:02 schistosoma_mansoni.wbpstranscript.interproterm.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 20:59 schistosoma_mansoni.wbpstranscript.interpro.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 21:00 schistosoma_mansoni.wbpstranscript.ortholog.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 21:00 schistosoma_mansoni.wbpstranscript.refseq.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 20:59 schistosoma_mansoni.wbpstranscript.symbol.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 21:02 schistosoma_mansoni.wbpstranscript.uniprot.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 20:59 schistosoma_mansoni.wbpstranscript.wbpsgene.tsv.failed
-rw-r--r-- 1 fg_atlas fg_pub       0 Oct 13 21:01 schistosoma_mansoni.wbpstranscript.wbpsprotein.tsv.failed
```

These are then merged as empty columns only with a header by the mergePropertiesIntoMatrix.pl script. This fix avoid those files that are not finished in .tsv to be used for the merge.



