### PR TITLE
A few tweaks to match Scala 2.13 `Iterator` and Ammonite 1.8 `Path`

### DIFF
--- a/src/Directories.sc
+++ b/src/Directories.sc
@@ -49,17 +49,13 @@ lazy val alternativeToCanonicalGoTermMapping = {
 val annsrcsPath = PROJECT_ROOT/"annsrcs"/"ensembl"
 val wbpsAnnsrcsPath = PROJECT_ROOT/"annsrcs"/"wbps"
 
-lazy val ANNOTATION_SOURCES: Seq[Path] = Option(System.getenv.get("ANNOTATION_SOURCES"))
-  .map(_.split(":").map(Path(_)).filter(exists).filter(_.isDir))
-match {
+lazy val ANNOTATION_SOURCES: Seq[Path] = Option(System.getenv.get("ANNOTATION_SOURCES")).map(_.split(":").map(Path(_)).filter(exists).filter(_.isDir)) match {
   case Some(paths) => ((paths.map(ls! _).flatten) ++ (List())).toList
   case None => ((ls! wbpsAnnsrcsPath) ++ (ls! annsrcsPath))
 }
 
-def annotationSources: Seq[Path] =
-  ANNOTATION_SOURCES
-  .filter{ case path =>
-    path.isFile && path.segments.last.matches("[a-z]+_[a-z]+")
+def annotationSources: Seq[Path] = ANNOTATION_SOURCES.filter { case path =>
+    path.isFile && path.segments.toList.last.matches("[a-z]+_[a-z]+")
   }
 
 /**
@@ -91,4 +87,4 @@ EXPERIMENT_SOURCES.map(println(_))
 /*
  For each path to experiments, we list all directories that begin with 'E-'
  */
-lazy val ANALYSIS_EXPERIMENTS = EXPERIMENT_SOURCES.map(ls(_)).flatten.filter(_.name startsWith "E-")
+lazy val ANALYSIS_EXPERIMENTS = EXPERIMENT_SOURCES.map(ls(_)).flatten.filter(_.toString startsWith "E-")

--- a/src/atlas/AtlasSpecies.sc
+++ b/src/atlas/AtlasSpecies.sc
@@ -1,4 +1,4 @@
-import $ivy.`org.json4s:json4s-native_2.12:3.5.0`
+import $ivy.`org.json4s:json4s-native_2.13:3.6.7`
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 import $file.^.property.AnnotationSource
@@ -70,7 +70,7 @@ object AtlasSpeciesFactory {
   }
 }
 
-def speciesName(annotationSource: AnnotationSource) = annotationSource.segments.last.capitalize
+def speciesName(annotationSource: AnnotationSource) = annotationSource.segments.toList.last.capitalize
 
 def atlasSpeciesFromAllAnnotationSources = {
   Combinators.combine(


### PR DESCRIPTION
I don’t know if you’ve got any plans of updating  the Ammonite/Scala stack, but if you do, this will be helpful. I wanted to run `AtlasSpecies.sc` on my laptop with a fresh, just-installed, version of Ammonite and I had to patch some code to make it work, since `Iterator` has lost the `last` method and same thing for `Path.name`.

A couple of useful references:
- https://www.scala-lang.org/api/current/scala/collection/Iterator.html
- http://ammonite.io/api/ops/ammonite/ops/Path.html